### PR TITLE
Allow cli with file name argument to be used from scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+colored.example.txt

--- a/cli.js
+++ b/cli.js
@@ -34,12 +34,12 @@ if (argv.indexOf('--version') !== -1) {
 	return;
 }
 
-if (process.stdin.isTTY) {
-	if (!input) {
-		help();
-		return;
-	}
+if (!input && process.stdin.isTTY) {
+	help();
+	return;
+}
 
+if (input) {
 	init(fs.readFileSync(input, 'utf8'));
 } else {
 	process.stdin.setEncoding('utf8');

--- a/test.js
+++ b/test.js
@@ -21,3 +21,13 @@ it('should strip color with CLI', function (cb) {
 		cb();
 	});
 });
+
+it('should strip color from file with CLI', function (cb) {
+	exec('echo "\u001b[0m\u001b[4m\u001b[42m\u001b[31mfoo\u001b[39m\u001b[49m\u001b[24mfoo\u001b[0m" > colored.example.txt', function (err, stdout) {
+    if (err) cb(err);
+    exec('./cli.js colored.example.txt', function (err, stdout) {
+      assert.equal(stdout, 'foofoo\n');
+      cb(err);
+    });
+  })
+});


### PR DESCRIPTION
When invoked via `exec()`/`system()`/whatever from a parent script, stdin is generally not a TTY. In the current version of strip-ansi, this prevents any arguments from being used as the filename even if provided.

The first commit adds this scenario as a test case (initially failing). The second commit allows the filename argument, if provided, to be used when scripting.

I found this when I tried to use strip-ansi in my CI pipeline to strip colourized diffs from my TAP result files but was perplexed by the result being an empty file. I am using the `cat file | strip-ansi > stripped.txt` form as a workaround for now.