### PR TITLE
Bump package dep on ansi-regex to unblock dependent chalk package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strip-ansi",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Strip ANSI escape codes",
   "license": "MIT",
   "repository": "sindresorhus/strip-ansi",
@@ -48,7 +48,7 @@
     "text"
   ],
   "dependencies": {
-    "ansi-regex": "^1.0.0"
+    "ansi-regex": "~1.1.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
Clone of current master branch and attempt to npm install fails on ansi-regex dependency requiring minor package adjustment. Thanks.